### PR TITLE
Include foundation.util.mediaQuery.js in default build, fixes #35

### DIFF
--- a/gulp/config.yml
+++ b/gulp/config.yml
@@ -64,7 +64,7 @@ javascript:
     # - "assets/vendor/foundation-sites/js/foundation.tooltip.js"
     # - "assets/vendor/foundation-sites/js/foundation.util.box.js"
     # - "assets/vendor/foundation-sites/js/foundation.util.keyboard.js"
-    # - "assets/vendor/foundation-sites/js/foundation.util.mediaQuery.js"
+    - "assets/vendor/foundation-sites/js/foundation.util.mediaQuery.js"
     # - "assets/vendor/foundation-sites/js/foundation.util.motion.js"
     # - "assets/vendor/foundation-sites/js/foundation.util.nest.js"
     # - "assets/vendor/foundation-sites/js/foundation.util.timerAndImageLoader.js"


### PR DESCRIPTION
Prevents the error message when displaying the default site:
Error in all.js (line 266): undefined is not an object (evaluating
'Foundation.MediaQuery._init')