### PR TITLE
Update Foundation Inport Path in _foundation.scss

### DIFF
--- a/assets/scss/foundation/_foundation.scss
+++ b/assets/scss/foundation/_foundation.scss
@@ -23,8 +23,8 @@
 // --------------------------------------------------
 // Behold, here are all the Foundation components.
 
-@import '../../vendor/foundation-sites/scss/foundation';
-@import '../../vendor/motion-ui/motion-ui';
+@import '../../bower_components/foundation-sites/scss/foundation';
+@import '../../bower_components/motion-ui/motion-ui';
 
 @include foundation-global-styles;
 @include foundation-grid;


### PR DESCRIPTION
- previously was getting an error when running `npm start` as the `../../vendor/` wasn't actually a directory so updated to `../../bower_components/` which is where those files live and now it compiles properly