### PR TITLE
RSS Feed Title Fix

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -3,7 +3,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
-        <title>{{ site.name | xml_escape }}</title>
+        <title>{{ site.title | xml_escape }}</title>
         <description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>      
         <link>{{ site.url }}</link>
         <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />


### PR DESCRIPTION
Fixed RSS feed to display title from Jekyll config file instead of being blank.